### PR TITLE
Add back-end proxy into front-end

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,9 @@ services:
       - backend
     networks:
       - frontend
-    # volumes:
-    #   - ./frontend:/app
+      - backend
+#     volumes:
+#      - ./frontend:/app
     ports:
       - "8080:8080"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,6 @@ COPY . /app
 ENV HOST=0.0.0.0
 ENV PORT=8080
 
-RUN yarn generate
+RUN yarn build
 
 CMD [ "yarn", "start" ]

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -3,7 +3,7 @@ import colors from 'vuetify/es5/util/colors'
 export default {
   // Target: https://go.nuxtjs.dev/config-target
   ssr: false,
-  target: 'static',
+  target: 'server',
 
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
@@ -43,11 +43,19 @@ export default {
 
   // Modules: https://go.nuxtjs.dev/config-modules
   modules: [
-    '@nuxt/http'
+    '@nuxt/http',
+    '@nuxtjs/proxy'
   ],
 
   http: {
-    baseURL: 'http://backend:80'
+    baseURL: '/api'
+  },
+
+  proxy: {
+    '/api/': {
+      target: 'http://backend',
+      pathRewrite: { '^/api/': '' }
+    }
   },
 
   // Vuetify module configuration: https://go.nuxtjs.dev/config-vuetify

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@nuxt/http": "^0.6.4",
+    "@nuxtjs/proxy": "^2.1.0",
     "core-js": "^3.8.3",
     "ipaddr.js": "^2.0.0",
     "nuxt": "^2.15.1"


### PR DESCRIPTION
Solves ASP-39.

This PR changes front-end building to use NuxtJS server instead of just generating static SPA files. This allows to implement a proxy to back-end API, solving API reachability issues from web-browser.

